### PR TITLE
[openvino] Refactored `openvino-road-seg-adas` example to use wasmedge-nn v0.5.2

### DIFF
--- a/openvino-road-segmentation-adas/rust/openvino-road-seg-adas/Cargo.toml
+++ b/openvino-road-segmentation-adas/rust/openvino-road-seg-adas/Cargo.toml
@@ -2,8 +2,7 @@
 authors = ["Sam Liu <sam@secondstate.io>"]
 edition = "2021"
 name = "openvino-road-seg-adas"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
-image = {version = "0.23.14", default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"]}
-wasmedge-nn = "0.5.0"
+wasmedge-nn = "0.5.2"

--- a/openvino-road-segmentation-adas/rust/openvino-road-seg-adas/Cargo.toml
+++ b/openvino-road-segmentation-adas/rust/openvino-road-seg-adas/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 
 [dependencies]
 image = {version = "0.23.14", default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"]}
-wasmedge-nn = "0.3"
+wasmedge-nn = "0.5.0"

--- a/openvino-road-segmentation-adas/rust/openvino-road-seg-adas/src/main.rs
+++ b/openvino-road-segmentation-adas/rust/openvino-road-seg-adas/src/main.rs
@@ -1,8 +1,7 @@
-use image::{io::Reader, DynamicImage};
 use std::env;
 use wasmedge_nn::{
-    cv,
-    nn::{ctx::WasiNnCtx, Dtype, ExecutionTarget, GraphEncoding},
+    cv::image_to_bytes,
+    nn::{ctx::WasiNnCtx, Dtype, ExecutionTarget, GraphEncoding, Tensor},
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -11,10 +10,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let model_bin_name: &str = &args[2];
     let image_name: &str = &args[3];
 
-    // load image
+    // load image and convert it to tensor
     println!("Load image file and convert it into tensor ...");
-    let tensor = cv::image_to_tensor(image_name.to_string(), 512, 896, Dtype::F32)?;
-
+    let bytes = image_to_bytes(image_name.to_string(), 512, 896, Dtype::F32)?;
+    let tensor = Tensor {
+        dimensions: &[1, 3, 512, 896],
+        r#type: Dtype::F32.into(),
+        data: bytes.as_slice(),
+    };
     // create wasi-nn context
     let mut ctx = WasiNnCtx::new()?;
 
@@ -66,28 +69,4 @@ fn dump<T>(
     std::fs::write(path, &dst_slice).expect("failed to write file");
 
     Ok(())
-}
-
-// Take the image located at 'path', open it, resize it to height x width, and then converts
-// the pixel precision to FP32. The resulting BGR pixel vector is then returned.
-fn image_to_tensor(path: String, height: u32, width: u32) -> Vec<u8> {
-    let pixels = Reader::open(path).unwrap().decode().unwrap();
-    let dyn_img: DynamicImage = pixels.resize_exact(width, height, image::imageops::Triangle);
-    let bgr_img = dyn_img.to_bgr8();
-    // Get an array of the pixel values
-    let raw_u8_arr: &[u8] = &bgr_img.as_raw()[..];
-    // Create an array to hold the f32 value of those pixels
-    let bytes_required = raw_u8_arr.len() * 4;
-    let mut u8_f32_arr: Vec<u8> = vec![0; bytes_required];
-
-    for i in 0..raw_u8_arr.len() {
-        // Read the number as a f32 and break it into u8 bytes
-        let u8_f32: f32 = raw_u8_arr[i] as f32;
-        let u8_bytes = u8_f32.to_ne_bytes();
-
-        for j in 0..4 {
-            u8_f32_arr[(i * 4) + j] = u8_bytes[j];
-        }
-    }
-    return u8_f32_arr;
 }

--- a/openvino-road-segmentation-adas/rust/openvino-road-seg-adas/src/main.rs
+++ b/openvino-road-segmentation-adas/rust/openvino-road-seg-adas/src/main.rs
@@ -1,6 +1,9 @@
 use image::{io::Reader, DynamicImage};
 use std::env;
-use wasmedge_nn::nn::{ctx::WasiNnCtx, Dtype, ExecutionTarget, GraphEncoding, Tensor};
+use wasmedge_nn::{
+    cv,
+    nn::{ctx::WasiNnCtx, Dtype, ExecutionTarget, GraphEncoding},
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
@@ -9,14 +12,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image_name: &str = &args[3];
 
     // load image
-    let tensor_data = image_to_tensor(image_name.to_string(), 512, 896);
-    println!("Load input tensor, size in bytes: {}", tensor_data.len());
-    let tensor = Tensor {
-        dimensions: &[1, 3, 512, 896],
-        r#type: Dtype::F32.into(),
-        data: &tensor_data,
-    };
+    println!("Load image file and convert it into tensor ...");
+    let tensor = cv::image_to_tensor(image_name.to_string(), 512, 896, Dtype::F32)?;
 
+    // create wasi-nn context
     let mut ctx = WasiNnCtx::new()?;
 
     println!("Load model files ...");


### PR DESCRIPTION
In this PR, refactored the example code of `openvino-road-seg-adas` and used the APIs in `wasmedge-nn v0.5.2` crate.