### PR TITLE
Remove redundant section in Cargo.toml

### DIFF
--- a/openvino-mobilenet-image/rust/Cargo.toml
+++ b/openvino-mobilenet-image/rust/Cargo.toml
@@ -9,8 +9,3 @@ publish = false
 [dependencies]
 image = { version = "0.23.14", default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"]  }
 wasi-nn = { version = "0.2.1" }
-
-# This crate is built with the wasm32-wasi target, so it's separate
-# from the main Wasmtime build, so use this directive to exclude it
-# from the parent directory's workspace.
-[workspace]

--- a/openvino-mobilenet-raw/rust/Cargo.toml
+++ b/openvino-mobilenet-raw/rust/Cargo.toml
@@ -8,8 +8,3 @@ publish = false
 
 [dependencies]
 wasi-nn = { version = "0.2.1" }
-
-# This crate is built with the wasm32-wasi target, so it's separate
-# from the main Wasmtime build, so use this directive to exclude it
-# from the parent directory's workspace.
-[workspace]

--- a/pytorch-mobilenet-image/rust/Cargo.toml
+++ b/pytorch-mobilenet-image/rust/Cargo.toml
@@ -9,8 +9,3 @@ publish = false
 [dependencies]
 image = { version = "0.23.14", default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"]  }
 wasi-nn = { version = "0.2.1" }
-
-# This crate is built with the wasm32-wasi target, so it's separate
-# from the main Wasmtime build, so use this directive to exclude it
-# from the parent directory's workspace.
-[workspace]

--- a/tflite-birds_v1-image/rust/tflite-bird/Cargo.toml
+++ b/tflite-birds_v1-image/rust/tflite-bird/Cargo.toml
@@ -9,8 +9,3 @@ publish = false
 [dependencies]
 image = { version = "0.23.14", default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"]  }
 wasi-nn = { version = "0.1.0" }
-
-# This crate is built with the wasm32-wasi target, so it's separate
-# from the main Wasmtime build, so use this directive to exclude it
-# from the parent directory's workspace.
-[workspace]


### PR DESCRIPTION
The unused section `workspace` causes those crates can't be member inside other crate's workspace.

I met this issue when runwasi use this crate as one of demo cases and try to compile it under runwasi root crate.
(The build test image flow was changed. Not depend on docker buildx anymore.)