### PR TITLE
[Examples] Update the wasi-nn crate dependency to 0.4.0

### DIFF
--- a/openvino-mobilenet-image/README.md
+++ b/openvino-mobilenet-image/README.md
@@ -10,7 +10,7 @@ This crate depends on the `wasi-nn` in the `Cargo.toml`:
 
 ```toml
 [dependencies]
-wasi-nn = "0.3.0"
+wasi-nn = "0.4.0"
 ```
 
 ## Build

--- a/openvino-mobilenet-image/rust/Cargo.toml
+++ b/openvino-mobilenet-image/rust/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 image = { version = "0.23.14", default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"]  }
-wasi-nn = { version = "0.3.0" }
+wasi-nn = { version = "0.4.0" }
 
 [workspace]

--- a/openvino-mobilenet-raw/README.md
+++ b/openvino-mobilenet-raw/README.md
@@ -10,7 +10,7 @@ This crate depends on the `wasi-nn` in the `Cargo.toml`:
 
 ```toml
 [dependencies]
-wasi-nn = "0.3.0"
+wasi-nn = "0.4.0"
 ```
 
 ## Build

--- a/openvino-mobilenet-raw/rust/Cargo.toml
+++ b/openvino-mobilenet-raw/rust/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-wasi-nn = { version = "0.3.0" }
+wasi-nn = { version = "0.4.0" }
 
 [workspace]

--- a/openvino-mobilenet-raw/rust/src/main.rs
+++ b/openvino-mobilenet-raw/rust/src/main.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::env;
 use std::fs;
 use wasi_nn;
@@ -16,18 +15,16 @@ pub fn main() {
     let weights = fs::read(model_bin_name).unwrap();
     println!("Read graph weights, size in bytes: {}", weights.len());
 
-    let graph = unsafe {
-        wasi_nn::load(
-            &[&xml.into_bytes(), &weights],
-            wasi_nn::GRAPH_ENCODING_OPENVINO,
-            wasi_nn::EXECUTION_TARGET_CPU,
-        )
-        .unwrap()
-    };
-    println!("Loaded graph into wasi-nn with ID: {}", graph);
+    let graph = wasi_nn::GraphBuilder::new(
+        wasi_nn::GraphEncoding::Openvino,
+        wasi_nn::ExecutionTarget::CPU,
+    )
+    .build_from_bytes(&[xml.into_bytes(), weights])
+    .unwrap();
+    println!("Loaded graph into wasi-nn with ID: {:?}", graph);
 
-    let context = unsafe { wasi_nn::init_execution_context(graph).unwrap() };
-    println!("Created wasi-nn execution context with ID: {}", context);
+    let mut context = graph.init_execution_context().unwrap();
+    println!("Created wasi-nn execution context with ID: {:?}", context);
 
     // Load a tensor that precisely matches the graph input tensor (see
     // `fixture/frozen_inference_graph.xml`).
@@ -36,30 +33,15 @@ pub fn main() {
     // for i in 0..10{
     //     println!("tensor -> {}", tensor_data[i]);
     // }
-    let tensor = wasi_nn::Tensor {
-        dimensions: &[1, 3, 224, 224],
-        type_: wasi_nn::TENSOR_TYPE_F32,
-        data: &tensor_data,
-    };
-    unsafe {
-        wasi_nn::set_input(context, 0, tensor).unwrap();
-    }
+    context
+        .set_input(0, wasi_nn::TensorType::F32, &[1, 3, 224, 224], &tensor_data)
+        .unwrap();
     // Execute the inference.
-    unsafe {
-        wasi_nn::compute(context).unwrap();
-    }
+    context.compute().unwrap();
     println!("Executed graph inference");
     // Retrieve the output.
     let mut output_buffer = vec![0f32; 1001];
-    unsafe {
-        wasi_nn::get_output(
-            context,
-            0,
-            &mut output_buffer[..] as *mut [f32] as *mut u8,
-            (output_buffer.len() * 4).try_into().unwrap(),
-        )
-        .unwrap();
-    }
+    context.get_output(0, &mut output_buffer).unwrap();
 
     let results = sort_results(&output_buffer);
     for i in 0..5 {

--- a/openvino-road-segmentation-adas/rust/openvino-road-segmentation-adas-basic/Cargo.toml
+++ b/openvino-road-segmentation-adas/rust/openvino-road-segmentation-adas-basic/Cargo.toml
@@ -5,4 +5,4 @@ name = "rust-road-segmentation-adas"
 version = "0.1.0"
 
 [dependencies]
-wasi-nn = "0.1.0"
+wasi-nn = "0.4.0"

--- a/pytorch-mobilenet-image/README.md
+++ b/pytorch-mobilenet-image/README.md
@@ -10,7 +10,7 @@ This crate depends on the `wasi-nn` in the `Cargo.toml`:
 
 ```toml
 [dependencies]
-wasi-nn = "0.3.0"
+wasi-nn = "0.4.0"
 ```
 
 ## Build
@@ -67,7 +67,6 @@ wasmedge --dir .:. wasmedge-wasinn-example-mobilenet-image.wasm mobilenet.pt inp
 You will get the output:
 
 ```console
-Read torchscript binaries, size in bytes: 14376924
 Loaded graph into wasi-nn with ID: 0
 Created wasi-nn execution context with ID: 0
 Read input tensor, size in bytes: 602112

--- a/pytorch-mobilenet-image/rust/Cargo.toml
+++ b/pytorch-mobilenet-image/rust/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 image = { version = "0.23.14", default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"]  }
-wasi-nn = { version = "0.3.0" }
+wasi-nn = { version = "0.4.0" }
 
 [workspace]

--- a/pytorch-mobilenet-image/rust/src/main.rs
+++ b/pytorch-mobilenet-image/rust/src/main.rs
@@ -1,7 +1,5 @@
 use image;
-use std::convert::TryInto;
 use std::env;
-use std::fs;
 use std::fs::File;
 use std::io::Read;
 use wasi_nn;
@@ -12,52 +10,29 @@ pub fn main() {
     let model_bin_name: &str = &args[1];
     let image_name: &str = &args[2];
 
-    let weights = fs::read(model_bin_name).unwrap();
-    println!(
-        "Read torchscript binaries, size in bytes: {}",
-        weights.len()
-    );
+    let graph = wasi_nn::GraphBuilder::new(
+        wasi_nn::GraphEncoding::Pytorch,
+        wasi_nn::ExecutionTarget::CPU,
+    )
+    .build_from_files([model_bin_name])
+    .unwrap();
+    println!("Loaded graph into wasi-nn with ID: {:?}", graph);
 
-    let graph = unsafe {
-        wasi_nn::load(
-            &[&weights],
-            wasi_nn::GRAPH_ENCODING_PYTORCH,
-            wasi_nn::EXECUTION_TARGET_CPU,
-        )
-        .unwrap()
-    };
-    println!("Loaded graph into wasi-nn with ID: {}", graph);
-
-    let context = unsafe { wasi_nn::init_execution_context(graph).unwrap() };
-    println!("Created wasi-nn execution context with ID: {}", context);
+    let mut context = graph.init_execution_context().unwrap();
+    println!("Created wasi-nn execution context with ID: {:?}", context);
 
     // Load a tensor that precisely matches the graph input tensor (see
     let tensor_data = image_to_tensor(image_name.to_string(), 224, 224);
     println!("Read input tensor, size in bytes: {}", tensor_data.len());
-    let tensor = wasi_nn::Tensor {
-        dimensions: &[1, 3, 224, 224],
-        type_: wasi_nn::TENSOR_TYPE_F32,
-        data: &tensor_data,
-    };
-    unsafe {
-        wasi_nn::set_input(context, 0, tensor).unwrap();
-    }
+    context
+        .set_input(0, wasi_nn::TensorType::F32, &[1, 3, 224, 224], &tensor_data)
+        .unwrap();
     // Execute the inference.
-    unsafe {
-        wasi_nn::compute(context).unwrap();
-    }
+    context.compute().unwrap();
     println!("Executed graph inference");
     // Retrieve the output.
     let mut output_buffer = vec![0f32; 1000];
-    unsafe {
-        wasi_nn::get_output(
-            context,
-            0,
-            &mut output_buffer[..] as *mut [f32] as *mut u8,
-            (output_buffer.len() * 4).try_into().unwrap(),
-        )
-        .unwrap();
-    }
+    context.get_output(0, &mut output_buffer).unwrap();
 
     let results = sort_results(&output_buffer);
     for i in 0..5 {


### PR DESCRIPTION
This PR update the wasi-nn crate dependency to 0.4.0. (This PR only changes the rust source code and README files, it does not change the wasm binary files.)