### PR TITLE
Update openvino workflows

### DIFF
--- a/.github/workflows/build_openvino_mobilenet.yml
+++ b/.github/workflows/build_openvino_mobilenet.yml
@@ -41,9 +41,6 @@ jobs:
           apt install -y libtbb2
 
       - name: Install OpenVINO
-        env:
-          OPENVINO_VERSION: "2023.0.0"
-          OPENVINO_YEAR: "2023"
         working-directory: scripts
         run: |
           bash install_openvino.sh
@@ -51,7 +48,7 @@ jobs:
       - name: Install WasmEdge with Wasi-NN OpenVINO plugin
         env:
           CMAKE_BUILD_TYPE: "Release"
-          VERSION: "0.13.2"
+          VERSION: "0.13.4"
         run: |
           ldconfig
           curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v $VERSION -p /usr/local --plugins wasi_nn-openvino
@@ -66,7 +63,7 @@ jobs:
           cargo build --target wasm32-wasi --release
           cd ..
           wasmedge --dir .:. ./rust/target/wasm32-wasi/release/wasmedge-wasinn-example-mobilenet.wasm mobilenet.xml mobilenet.bin tensor-1x224x224x3-f32.bgr
-      
+
       - name: Build and run openvino-mobilenet-image
         working-directory: openvino-mobilenet-image
         run: |

--- a/.github/workflows/build_openvino_road_seg_adas.yml
+++ b/.github/workflows/build_openvino_road_seg_adas.yml
@@ -40,9 +40,6 @@ jobs:
           apt install -y libtbb2
 
       - name: Install OpenVINO
-        env:
-          OPENVINO_VERSION: "2023.0.0"
-          OPENVINO_YEAR: "2023"
         working-directory: scripts
         run: |
           bash install_openvino.sh
@@ -50,7 +47,7 @@ jobs:
       - name: Install WasmEdge with Wasi-NN OpenVINO plugin
         env:
           CMAKE_BUILD_TYPE: "Release"
-          VERSION: "0.13.2"
+          VERSION: "0.13.4"
         run: |
           ldconfig
           curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v $VERSION -p /usr/local --plugins wasi_nn-openvino

--- a/scripts/install_openvino.sh
+++ b/scripts/install_openvino.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -e
-echo "Installing OpenVINO with version 2023.0.0"
+echo "Installing OpenVINO with version 2023.0.2"
 wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
 apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
 echo "deb https://apt.repos.intel.com/openvino/2023 ubuntu20 main" | tee /etc/apt/sources.list.d/intel-openvino-2023.list
 apt update
 apt-get -y install openvino
 ldconfig
+export PATH=/usr/lib/x86_64-linux-gnu:$PATH


### PR DESCRIPTION
In this PR, the `build_openvino_mobilenet` and `build_openvino_road_seg_adas` workflows are updated to use `WasmEdge 0.13.4`. In addition, the `install_openvino` script is improved.