### PR TITLE
use more appropriate dimensions for text inputs

### DIFF
--- a/openvinogenai-raw/rust/src/main.rs
+++ b/openvinogenai-raw/rust/src/main.rs
@@ -20,8 +20,8 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("done");
 
     print!("Set input tensor ...");
-    let input_dims = vec![1];
     let tensor_data = "Hello, how are you?".as_bytes().to_vec();
+    let input_dims = vec![tensor_data.len()];
     context.set_input(0, TensorType::U8, &input_dims, tensor_data)?;
     println!("done");
 

--- a/wasmedge-chatTTS/src/main.rs
+++ b/wasmedge-chatTTS/src/main.rs
@@ -29,10 +29,10 @@ fn main() {
         .init_execution_context()
         .expect("Failed to init context");
     context
-        .set_input(0, TensorType::U8, &[1], &tensor_data)
+        .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
         .expect("Failed to set input");
     context
-        .set_input(1, TensorType::U8, &[1], &config_data)
+        .set_input(1, TensorType::U8, &[config_data.len()], &config_data)
         .expect("Failed to set input");
     context.compute().expect("Failed to compute");
     let output_bytes = get_data_from_context(&context, 0);

--- a/wasmedge-ggml/basic/src/main.rs
+++ b/wasmedge-ggml/basic/src/main.rs
@@ -50,7 +50,7 @@ fn get_options_from_env() -> Value {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 #[allow(dead_code)]
@@ -58,7 +58,7 @@ fn set_metadata_to_context(
     context: &mut GraphExecutionContext,
     data: Vec<u8>,
 ) -> Result<(), Error> {
-    context.set_input(1, TensorType::U8, &[1], &data)
+    context.set_input(1, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -110,7 +110,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
         context.compute().expect("Failed to compute");

--- a/wasmedge-ggml/chatml/src/main.rs
+++ b/wasmedge-ggml/chatml/src/main.rs
@@ -40,7 +40,7 @@ fn get_options_from_env() -> Value {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 #[allow(dead_code)]
@@ -48,7 +48,7 @@ fn set_metadata_to_context(
     context: &mut GraphExecutionContext,
     data: Vec<u8>,
 ) -> Result<(), Error> {
-    context.set_input(1, TensorType::U8, &[1], &data)
+    context.set_input(1, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -108,7 +108,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
 

--- a/wasmedge-ggml/command-r/src/main.rs
+++ b/wasmedge-ggml/command-r/src/main.rs
@@ -39,7 +39,7 @@ fn get_options_from_env() -> Value {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 #[allow(dead_code)]
@@ -47,7 +47,7 @@ fn set_metadata_to_context(
     context: &mut GraphExecutionContext,
     data: Vec<u8>,
 ) -> Result<(), Error> {
-    context.set_input(1, TensorType::U8, &[1], &data)
+    context.set_input(1, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -106,7 +106,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
 

--- a/wasmedge-ggml/embedding/src/main.rs
+++ b/wasmedge-ggml/embedding/src/main.rs
@@ -37,7 +37,7 @@ fn get_options_from_env() -> Value {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 #[allow(dead_code)]
@@ -45,7 +45,7 @@ fn set_metadata_to_context(
     context: &mut GraphExecutionContext,
     data: Vec<u8>,
 ) -> Result<(), Error> {
-    context.set_input(1, TensorType::U8, &[1], &data)
+    context.set_input(1, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -98,7 +98,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .unwrap();
         println!("Raw Embedding Output:");
         context.compute().unwrap();

--- a/wasmedge-ggml/gemma-3/src/base64.rs
+++ b/wasmedge-ggml/gemma-3/src/base64.rs
@@ -58,7 +58,7 @@ fn get_options_from_env() -> HashMap<&'static str, Value> {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -107,7 +107,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
 

--- a/wasmedge-ggml/gemma-3/src/main.rs
+++ b/wasmedge-ggml/gemma-3/src/main.rs
@@ -64,7 +64,7 @@ fn get_options_from_env() -> HashMap<&'static str, Value> {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -113,7 +113,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
 

--- a/wasmedge-ggml/gemma/src/main.rs
+++ b/wasmedge-ggml/gemma/src/main.rs
@@ -45,7 +45,7 @@ fn get_options_from_env() -> Value {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 #[allow(dead_code)]
@@ -53,7 +53,7 @@ fn set_metadata_to_context(
     context: &mut GraphExecutionContext,
     data: Vec<u8>,
 ) -> Result<(), Error> {
-    context.set_input(1, TensorType::U8, &[1], &data)
+    context.set_input(1, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -112,7 +112,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
         context.compute().expect("Failed to compute");

--- a/wasmedge-ggml/grammar/src/main.rs
+++ b/wasmedge-ggml/grammar/src/main.rs
@@ -43,7 +43,7 @@ fn get_options_from_env() -> Value {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 #[allow(dead_code)]
@@ -51,7 +51,7 @@ fn set_metadata_to_context(
     context: &mut GraphExecutionContext,
     data: Vec<u8>,
 ) -> Result<(), Error> {
-    context.set_input(1, TensorType::U8, &[1], &data)
+    context.set_input(1, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -128,7 +128,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
 

--- a/wasmedge-ggml/json-schema/src/main.rs
+++ b/wasmedge-ggml/json-schema/src/main.rs
@@ -46,7 +46,7 @@ fn get_options_from_env() -> Value {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 #[allow(dead_code)]
@@ -54,7 +54,7 @@ fn set_metadata_to_context(
     context: &mut GraphExecutionContext,
     data: Vec<u8>,
 ) -> Result<(), Error> {
-    context.set_input(1, TensorType::U8, &[1], &data)
+    context.set_input(1, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -140,7 +140,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
 

--- a/wasmedge-ggml/llama-stream/src/main.rs
+++ b/wasmedge-ggml/llama-stream/src/main.rs
@@ -51,7 +51,7 @@ fn get_options_from_env() -> Value {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 #[allow(dead_code)]
@@ -59,7 +59,7 @@ fn set_metadata_to_context(
     context: &mut GraphExecutionContext,
     data: Vec<u8>,
 ) -> Result<(), Error> {
-    context.set_input(1, TensorType::U8, &[1], &data)
+    context.set_input(1, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize, is_single: bool) -> String {
@@ -130,7 +130,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
 

--- a/wasmedge-ggml/llama/src/main.rs
+++ b/wasmedge-ggml/llama/src/main.rs
@@ -49,7 +49,7 @@ fn get_options_from_env() -> Value {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 #[allow(dead_code)]
@@ -57,7 +57,7 @@ fn set_metadata_to_context(
     context: &mut GraphExecutionContext,
     data: Vec<u8>,
 ) -> Result<(), Error> {
-    context.set_input(1, TensorType::U8, &[1], &data)
+    context.set_input(1, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -116,7 +116,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
 

--- a/wasmedge-ggml/llava-base64-stream/src/main.rs
+++ b/wasmedge-ggml/llava-base64-stream/src/main.rs
@@ -50,7 +50,7 @@ fn get_options_from_env() -> HashMap<&'static str, Value> {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize, is_single: bool) -> String {
@@ -103,7 +103,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
         context.compute().expect("Failed to compute");

--- a/wasmedge-ggml/llava/src/main.rs
+++ b/wasmedge-ggml/llava/src/main.rs
@@ -56,7 +56,7 @@ fn get_options_from_env() -> HashMap<&'static str, Value> {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -106,7 +106,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
 

--- a/wasmedge-ggml/multimodel/src/main.rs
+++ b/wasmedge-ggml/multimodel/src/main.rs
@@ -54,7 +54,7 @@ fn get_options_from_env() -> Value {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 #[allow(dead_code)]
@@ -62,7 +62,7 @@ fn set_metadata_to_context(
     context: &mut GraphExecutionContext,
     data: Vec<u8>,
 ) -> Result<(), Error> {
-    context.set_input(1, TensorType::U8, &[1], &data)
+    context.set_input(1, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {

--- a/wasmedge-ggml/nnrpc/src/main.rs
+++ b/wasmedge-ggml/nnrpc/src/main.rs
@@ -39,7 +39,7 @@ fn get_options_from_env() -> Value {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 #[allow(dead_code)]
@@ -47,7 +47,7 @@ fn set_metadata_to_context(
     context: &mut GraphExecutionContext,
     data: Vec<u8>,
 ) -> Result<(), Error> {
-    context.set_input(1, TensorType::U8, &[1], &data)
+    context.set_input(1, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -106,7 +106,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         // Get the number of input tokens and llama.cpp versions.
         let input_metadata = get_metadata_from_context(&context);

--- a/wasmedge-ggml/qwen/src/main.rs
+++ b/wasmedge-ggml/qwen/src/main.rs
@@ -39,7 +39,7 @@ fn get_options_from_env() -> Value {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {

--- a/wasmedge-ggml/qwen2vl/src/main.rs
+++ b/wasmedge-ggml/qwen2vl/src/main.rs
@@ -56,7 +56,7 @@ fn get_options_from_env() -> HashMap<&'static str, Value> {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> String {
@@ -105,7 +105,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
 

--- a/wasmedge-ggml/test/phi-3/src/main.rs
+++ b/wasmedge-ggml/test/phi-3/src/main.rs
@@ -69,7 +69,7 @@ fn main() {
     println!("Prompt:\n{}", prompt);
     let tensor_data = prompt.as_bytes().to_vec();
     context
-        .set_input(0, TensorType::U8, &[1], &tensor_data)
+        .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
         .expect("Failed to set input");
     println!("Response:");
 

--- a/wasmedge-ggml/test/set-input-twice/src/main.rs
+++ b/wasmedge-ggml/test/set-input-twice/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
 
@@ -86,7 +86,7 @@ fn main() {
 
         // Set the prompt, twice.
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
 
         // Get the number of input tokens and llama.cpp versions.

--- a/wasmedge-ggml/test/unload/src/main.rs
+++ b/wasmedge-ggml/test/unload/src/main.rs
@@ -73,7 +73,7 @@ fn main() {
         println!("Prompt:\n{}", prompt);
         let tensor_data = prompt.as_bytes().to_vec();
         context
-            .set_input(0, TensorType::U8, &[1], &tensor_data)
+            .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
             .expect("Failed to set input");
         println!("Response:");
 

--- a/wasmedge-ggml/tts/src/main.rs
+++ b/wasmedge-ggml/tts/src/main.rs
@@ -79,7 +79,7 @@ fn get_options_from_env() -> HashMap<&'static str, Value> {
 }
 
 fn set_data_to_context(context: &mut GraphExecutionContext, data: Vec<u8>) -> Result<(), Error> {
-    context.set_input(0, TensorType::U8, &[1], &data)
+    context.set_input(0, TensorType::U8, &[data.len()], &data)
 }
 
 fn get_data_from_context(context: &GraphExecutionContext, index: usize) -> Vec<u8> {
@@ -127,7 +127,7 @@ fn main() {
     println!("Prompt:\n{}", prompt);
     let tensor_data = prompt.as_bytes().to_vec();
     context
-        .set_input(0, TensorType::U8, &[1], &tensor_data)
+        .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
         .expect("Failed to set input");
 
     // Get the number of input tokens and llama.cpp versions.

--- a/wasmedge-mlx/llama/src/main.rs
+++ b/wasmedge-mlx/llama/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
         .expect("Failed to init context");
     let tensor_data = prompt.as_bytes().to_vec();
     context
-        .set_input(0, TensorType::U8, &[1], &tensor_data)
+        .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
         .expect("Failed to set input");
     context.compute().expect("Failed to compute");
     let output = get_output_from_context(&context);

--- a/wasmedge-mlx/vlm/src/main.rs
+++ b/wasmedge-mlx/vlm/src/main.rs
@@ -82,15 +82,15 @@ fn main() {
 
     let tensor_data = model_inputs["input_ids"].to_bytes();
     context
-        .set_input(0, TensorType::U8, &[1], &tensor_data)
+        .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
         .expect("Failed to set input");
     let tensor_data = model_inputs["pixel_values"].to_bytes();
     context
-        .set_input(1, TensorType::U8, &[1], &tensor_data)
+        .set_input(1, TensorType::U8, &[tensor_data.len()], &tensor_data)
         .expect("Failed to set input");
     let tensor_data = model_inputs["mask"].to_bytes();
     context
-        .set_input(2, TensorType::U8, &[1], &tensor_data)
+        .set_input(2, TensorType::U8, &[tensor_data.len()], &tensor_data)
         .expect("Failed to set input");
 
     context.compute().expect("Failed to compute");

--- a/wasmedge-neuralspeed/src/main.rs
+++ b/wasmedge-neuralspeed/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
         .init_execution_context()
         .expect("Failed to init context");
     context
-        .set_input(0, TensorType::U8, &[1], &tensor_data)
+        .set_input(0, TensorType::U8, &[tensor_data.len()], &tensor_data)
         .expect("Failed to set input");
     context.compute().expect("Failed to compute");
     let output_bytes = get_output_from_context(&context);

--- a/wasmedge-piper/src/main.rs
+++ b/wasmedge-piper/src/main.rs
@@ -17,7 +17,12 @@ fn main() {
     // set the input text
     let text = "Welcome to the world of speech synthesis!";
     context
-        .set_input(0, wasmedge_wasi_nn::TensorType::U8, &[1], text.as_bytes())
+        .set_input(
+            0,
+            wasmedge_wasi_nn::TensorType::U8,
+            &[text.len()],
+            text.as_bytes(),
+        )
         .unwrap();
 
     // synthesize the audio


### PR DESCRIPTION
for text data, use &[text.len()] for its dimensions, instead of &[1].

note that wasmedge currently ignores the dimensions.

i tested wasmedge-ggml/llama with wasm-micro-runtime.

i build-tested others except the one which doesn't buildeven without this change.
(https://github.com/second-state/WasmEdge-WASINN-examples/issues/199)

cf. https://github.com/second-state/WasmEdge-WASINN-examples/issues/196