### PR TITLE
Revert "tflite: downgrade wasi-nn from 0.6.0 to 0.4.0"

### DIFF
--- a/tflite-birds_v1-image/rust/Cargo.toml
+++ b/tflite-birds_v1-image/rust/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 image = { version = "0.23.14", default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"]  }
-wasi-nn = "0.4.0"
+wasi-nn = "0.6.0"
 
 [workspace]


### PR DESCRIPTION
This reverts commit 02e0108627ff94abc890a646e1f8f7dc3fdf21a1.

it seems that 0.4.0 has U8 == 2 and 0.6.0 has U8 == 3. the latter seems to match the wasi-nn version which WasmEdge and WAMR currently implement.
cf. https://github.com/WasmEdge/WasmEdge/blob/1b757f376d3b49a26da95decbaef5a36bd835121/plugins/wasi_nn/wasinntypes.h#L33

https://github.com/second-state/WasmEdge-WASINN-examples/pull/175 downgraded wasi-nn without mentioning any reasons. i have no idea what was the motivation of the downgrade.